### PR TITLE
Search beatmaps by hash

### DIFF
--- a/server/src/routes/search.ts
+++ b/server/src/routes/search.ts
@@ -28,4 +28,18 @@ router.get('/text/:page?', async ctx => {
   return (ctx.body = maps)
 })
 
+router.get('/hash/:page?', async ctx => {
+  const page = Math.max(0, Number.parseInt(ctx.params.page, 10)) || 0
+  const query = ctx.query.q
+  if (!query) throw ERR_NO_QUERY
+
+  const maps = await paginate(
+    Beatmap,
+    { hash: query },
+    { page, populate: 'uploader' }
+  )
+
+  return (ctx.body = maps)
+})
+
 export { router as searchRouter }


### PR DESCRIPTION
## Proposed Changes
I have a tool relying on the search by hash that beatsaver used to offer (useful to connect with scoresaber). This very simple PR adds it back.

## Platforms
This pull request modifies: *(select all that apply)*
- [ ] Client
- [x] Server

## Types of Changes
This pull request is contains: *(select all that apply)*
- [ ] Bug fixes *(non-breaking change which fixes an issue)*
- [x] New features *(non-breaking change which adds functionality)*
- [ ] Breaking changes *(fix or feature that would cause existing functionality to not work as expected)*

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/lolPants/beatsaver-reloaded/blob/master/.github/CONTRIBUTING.md)
- [x] I have checked the changes adhere to the project's style guide and all tests pass
- [x] I have (to the best of my ability) checked for vulnerabilities, or any ways that my code could be abused and concluded that it is safe to run in production

## Further Comments
I understand that the new version is taking a lot of effort and this might not be the priority. Hopefully that helps out.