### PR TITLE
Support middle clicking beatmap results

### DIFF
--- a/client/src/sass/_beatmap-result.scss
+++ b/client/src/sass/_beatmap-result.scss
@@ -1,4 +1,4 @@
-div.beatmap-result {
+a.beatmap-result {
   $radius: 8px;
   margin-bottom: 14px;
   border-radius: $radius;

--- a/client/src/ts/components/Beatmap/BeatmapResult.tsx
+++ b/client/src/ts/components/Beatmap/BeatmapResult.tsx
@@ -1,4 +1,3 @@
-import { push as pushFn } from 'connected-react-router'
 import dateFormat from 'dateformat'
 import TimeAgo from 'javascript-time-ago'
 import en from 'javascript-time-ago/locale/en'
@@ -8,7 +7,6 @@ import React, {
   useEffect,
   useState,
 } from 'react'
-import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
 import { IBeatmap } from '../../remote/beatmap'
 
@@ -18,23 +16,12 @@ TimeAgo.addLocale(en)
 const timeAgo = new TimeAgo('en-US')
 const SEVEN_DAYS = 1000 * 60 * 60 * 24 * 7
 
-interface IConnectedProps {
-  push: typeof pushFn
-}
-
-interface IPassedProps {
+interface IProps {
   map: IBeatmap
 }
 
-type IProps = IConnectedProps & IPassedProps
-
-const BeatmapResult: FunctionComponent<IProps> = ({ map, push }) => {
+const BeatmapResult: FunctionComponent<IProps> = ({ map }) => {
   const [image, setImage] = useState(undefined as string | undefined)
-
-  const handleClick = (e: MouseEvent<HTMLDivElement>) => {
-    if (e.target instanceof HTMLAnchorElement) return
-    else push(`/beatmap/${map.key}`)
-  }
 
   const uploaded = new Date(map.uploaded)
   const uploadedStr =
@@ -60,7 +47,7 @@ const BeatmapResult: FunctionComponent<IProps> = ({ map, push }) => {
   }, [])
 
   return (
-    <div className='beatmap-result' onClick={e => handleClick(e)}>
+    <Link className='beatmap-result' to={`/beatmap/${map.key}`}>
       <div className='cover'>
         <img
           src={image || Placeholder}
@@ -103,13 +90,8 @@ const BeatmapResult: FunctionComponent<IProps> = ({ map, push }) => {
           ) : null}
         </div>
       </div>
-    </div>
+    </Link>
   )
 }
 
-const ConnectedBeatmapResult = connect(
-  null,
-  { push: pushFn }
-)(BeatmapResult)
-
-export { ConnectedBeatmapResult as BeatmapResult }
+export { BeatmapResult }


### PR DESCRIPTION
## Proposed Changes
This PR replaces the previous `div` tag and `onClick` listener used in beatmap results with `react-router-dom`'s `Link` tag. By doing this, beatmap results are both made more accessible (links now show their destination in the browser's status bar on hover as we're using an anchor tag instead) and middle clicking beatmap results is also supported (which was the main pain-point which caused me to open this PR).

## Platforms
This pull request modifies: *(select all that apply)*
- [x] Client
- [ ] Server

## Types of Changes
This pull request is contains: *(select all that apply)*
- [x] Bug fixes *(non-breaking change which fixes an issue)*
- [ ] New features *(non-breaking change which adds functionality)*
- [ ] Breaking changes *(fix or feature that would cause existing functionality to not work as expected)*

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/lolPants/beatsaver-reloaded/blob/master/.github/CONTRIBUTING.md)
- [x] I have checked the changes adhere to the project's style guide and all tests pass
- [x] I have (to the best of my ability) checked for vulnerabilities, or any ways that my code could be abused and concluded that it is safe to run in production