### PR TITLE
Made error message when info.dat not found more helpful to the user.

### DIFF
--- a/client/src/ts/routes/Upload.tsx
+++ b/client/src/ts/routes/Upload.tsx
@@ -145,7 +145,7 @@ const Upload: FunctionComponent<IProps> = ({ user, push, replace }) => {
           return setFileErr('Beatmap already exists!')
 
         case 'ERR_BEATMAP_INFO_NOT_FOUND':
-          setFileErr('Beatmap does not contain an info.dat file!')
+          setFileErr('Beatmap does not contain an info.dat file. Perhaps you zipped the folder rather than zipping the map files directly?')
           return showProblems()
 
         case 'ERR_BEATMAP_INFO_INVALID':


### PR DESCRIPTION
## Proposed Changes
Changed error message when info.dat isn't found to suggest the user may have zipped the folder instead of the loose beatmap files.

## Platforms
This pull request modifies: *(select all that apply)*
- [x] Client
- [ ] Server

## Types of Changes
This pull request is contains: *(select all that apply)*
- [x] Bug fixes *(non-breaking change which fixes an issue)*
- [ ] New features *(non-breaking change which adds functionality)*
- [ ] Breaking changes *(fix or feature that would cause existing functionality to not work as expected)*

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/lolPants/beatsaver-reloaded/blob/master/.github/CONTRIBUTING.md)
- [x] I have checked the changes adhere to the project's style guide and all tests pass
- [x] I have (to the best of my ability) checked for vulnerabilities, or any ways that my code could be abused and concluded that it is safe to run in production

## Further Comments
People keep complaining about not understanding that zipping the folder and not the files is bad.
