### PR TITLE
Replaced 'Download' with 'OneClick install' in Beatmap results

### DIFF
--- a/client/src/sass/_beatmap-result.scss
+++ b/client/src/sass/_beatmap-result.scss
@@ -61,14 +61,17 @@ div.beatmap-result {
         text-align: right;
         color: rgb(23, 23, 24);
       }
-
+      
+      & .resultbuttons {
+        margin-right: -3px;
+        margin-bottom: -1.5px;
+      }
+      
       & a, button {
         color: $text;
         padding: 8px 20px;
 
-        margin-right: $content-padding * -1;
-        margin-bottom: $content-padding * -1;
-        border-radius: 0 0 $radius 0;
+        margin-right: -5;
 
         $border: 1px solid rgba(0, 0, 0, .1);
         border-top: $border;
@@ -76,6 +79,10 @@ div.beatmap-result {
 
         background-color: rgba(255, 255, 255, .4);
         transition: background-color 100ms ease;
+        
+        &:last-child {
+          border-radius: 0 0 $radius 0;
+        }
 
         &:hover {
           background-color: rgba(0, 0, 0, .05);

--- a/client/src/sass/_beatmap-result.scss
+++ b/client/src/sass/_beatmap-result.scss
@@ -61,12 +61,11 @@ div.beatmap-result {
         text-align: right;
         color: rgb(23, 23, 24);
       }
-      
-      & .resultbuttons {
-        margin-right: -3px;
-        margin-bottom: -1.5px;
+
+      & .is-button-group {
+        margin: -1px -8px;
       }
-      
+
       & a, button {
         color: $text;
         padding: 8px 20px;
@@ -79,7 +78,7 @@ div.beatmap-result {
 
         background-color: rgba(255, 255, 255, .4);
         transition: background-color 100ms ease;
-        
+
         &:last-child {
           border-radius: 0 0 $radius 0;
         }

--- a/client/src/ts/components/Beatmap/BeatmapResult.tsx
+++ b/client/src/ts/components/Beatmap/BeatmapResult.tsx
@@ -86,7 +86,7 @@ const BeatmapResult: FunctionComponent<IProps> = ({ map }) => {
             <BeatmapStats map={map} hideTime={true} />
           </div>
 
-          <a href={map.downloadURL}>Download</a>
+          <a href={`beatsaver://${map.key}`}>OneClick&trade; Install</a>
         </div>
       </div>
     </div>

--- a/client/src/ts/components/Beatmap/BeatmapResult.tsx
+++ b/client/src/ts/components/Beatmap/BeatmapResult.tsx
@@ -85,9 +85,10 @@ const BeatmapResult: FunctionComponent<IProps> = ({ map }) => {
           <div className='stats'>
             <BeatmapStats map={map} hideTime={true} />
           </div>
-          <div className="resultbuttons">
-	          <a href={map.downloadURL}>Download</a>
-	          <a href={`beatsaver://${map.key}`}>OneClick&trade;</a>
+
+          <div className='is-button-group'>
+            <a href={`beatsaver://${map.key}`}>OneClick&trade;</a>
+            <a href={map.downloadURL}>Download</a>
           </div>
         </div>
       </div>

--- a/client/src/ts/components/Beatmap/BeatmapResult.tsx
+++ b/client/src/ts/components/Beatmap/BeatmapResult.tsx
@@ -85,7 +85,7 @@ const BeatmapResult: FunctionComponent<IProps> = ({ map }) => {
           <div className='stats'>
             <BeatmapStats map={map} hideTime={true} />
           </div>
-          <div class="resultbuttons">
+          <div className="resultbuttons">
 	          <a href={map.downloadURL}>Download</a>
 	          <a href={`beatsaver://${map.key}`}>OneClick&trade;</a>
           </div>

--- a/client/src/ts/components/Beatmap/BeatmapResult.tsx
+++ b/client/src/ts/components/Beatmap/BeatmapResult.tsx
@@ -85,8 +85,15 @@ const BeatmapResult: FunctionComponent<IProps> = ({ map }) => {
           <div className='stats'>
             <BeatmapStats map={map} hideTime={true} />
           </div>
-
-          <a href={`beatsaver://${map.key}`}>OneClick&trade; Install</a>
+          
+          <ul>
+            <li style='display:inline-block'>
+    	        <a href={map.downloadURL}>Download</a>
+	          </li>
+            <li style='display:inline-block'>
+              <a href={`beatsaver://${map.key}`}>OneClick&trade; Install</a>
+   	        </li>
+          </ul>
         </div>
       </div>
     </div>

--- a/client/src/ts/components/Beatmap/BeatmapResult.tsx
+++ b/client/src/ts/components/Beatmap/BeatmapResult.tsx
@@ -85,15 +85,10 @@ const BeatmapResult: FunctionComponent<IProps> = ({ map }) => {
           <div className='stats'>
             <BeatmapStats map={map} hideTime={true} />
           </div>
-          
-          <ul>
-            <li style='display:inline-block'>
-    	        <a href={map.downloadURL}>Download</a>
-	          </li>
-            <li style='display:inline-block'>
-              <a href={`beatsaver://${map.key}`}>OneClick&trade; Install</a>
-   	        </li>
-          </ul>
+          <div class="resultbuttons">
+	          <a href={map.downloadURL}>Download</a>
+	          <a href={`beatsaver://${map.key}`}>OneClick&trade;</a>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Proposed Changes
_Please describe the changes this PR makes and why it should be merged. If it fixes a bug or resolves a feature request, be sure to reference that issue so it can be closed automatically._
I replaced the Download button in the Beatmap Results with the OneClick install button. I've done this because I think more people use the OneClick install button than the Download button. This decreases traffic and makes installing maps quicker/easier.

## Platforms
This pull request modifies: *(select all that apply)*
- [x] Client
- [ ] Server

## Types of Changes
This pull request is contains: *(select all that apply)*
- [ ] Bug fixes *(non-breaking change which fixes an issue)*
- [x] New features *(non-breaking change which adds functionality)*
- [ ] Breaking changes *(fix or feature that would cause existing functionality to not work as expected)*

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/lolPants/beatsaver-reloaded/blob/master/.github/CONTRIBUTING.md)
- [x] I have checked the changes adhere to the project's style guide and all tests pass
- [x] I have (to the best of my ability) checked for vulnerabilities, or any ways that my code could be abused and concluded that it is safe to run in production