### PR TITLE
Additional error info for "Beatmap is invalid!" error message

### DIFF
--- a/client/src/ts/routes/Upload.tsx
+++ b/client/src/ts/routes/Upload.tsx
@@ -133,7 +133,11 @@ const Upload: FunctionComponent<IProps> = ({ user, push, replace }) => {
         if (resp.fields.some(x => x.path === 'name')) {
           setTitleErr('Title is invalid!')
         } else {
-          setFileErr('Beatmap is invalid!')
+          setFileErr(
+            `Beatmap is invalid! Cause: ${resp.fields
+              .map(x => x.path)
+              .join('\n')}`
+          )
           showProblems()
         }
 

--- a/client/src/ts/routes/Upload.tsx
+++ b/client/src/ts/routes/Upload.tsx
@@ -136,7 +136,7 @@ const Upload: FunctionComponent<IProps> = ({ user, push, replace }) => {
           setFileErr(
             `Beatmap is invalid! Cause: ${resp.fields
               .map(x => x.path)
-              .join('\n')}`
+              .join(', ')}`
           )
           showProblems()
         }


### PR DESCRIPTION
## Proposed Changes
Adds some simple additional info for the "Beatmap is invalid!" error message

## Platforms
This pull request modifies: *(select all that apply)*
- [x] Client
- [ ] Server

## Types of Changes
This pull request is contains: *(select all that apply)*
- [ ] Bug fixes *(non-breaking change which fixes an issue)*
- [x] New features *(non-breaking change which adds functionality)*
- [ ] Breaking changes *(fix or feature that would cause existing functionality to not work as expected)*

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/lolPants/beatsaver-reloaded/blob/master/.github/CONTRIBUTING.md)
- [x] I have checked the changes adhere to the project's style guide and all tests pass
- [x] I have (to the best of my ability) checked for vulnerabilities, or any ways that my code could be abused and concluded that it is safe to run in production

## Further Comments
![image](https://user-images.githubusercontent.com/27714637/67209640-90d0ed00-f3cc-11e9-8438-6d2e36f95738.png)
![image](https://user-images.githubusercontent.com/27714637/67209820-ead1b280-f3cc-11e9-8389-d94e59d3b9d4.png)

This could probably be expanded to have a more helpful error message for each case, but it at least gives the user a clue as to what is wrong with the invalid beatmap.