### PR TITLE
Fix wrong variable in beatmap parsing

### DIFF
--- a/server/src/routes/upload/parseBeatmap.ts
+++ b/server/src/routes/upload/parseBeatmap.ts
@@ -161,7 +161,7 @@ export const parseBeatmap: (
       const length =
         infoJSON._beatsPerMinute === 0
           ? 0
-          : (duration / infoJSON._beatsPerMinute) * 60
+          : (charDuration / infoJSON._beatsPerMinute) * 60
 
       return {
         duration: charDuration,


### PR DESCRIPTION
## Proposed Changes
Fixed #56 

## Platforms
This pull request modifies: *(select all that apply)*
- [ ] Client
- [x] Server

## Types of Changes
This pull request is contains: *(select all that apply)*
- [x] Bug fixes *(non-breaking change which fixes an issue)*
- [ ] New features *(non-breaking change which adds functionality)*
- [ ] Breaking changes *(fix or feature that would cause existing functionality to not work as expected)*

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/lolPants/beatsaver-reloaded/blob/master/.github/CONTRIBUTING.md)
- [x] I have checked the changes adhere to the project's style guide and all tests pass
- [x] I have (to the best of my ability) checked for vulnerabilities, or any ways that my code could be abused and concluded that it is safe to run in production

## Further Comments
Looks like this variable was missed on commit f35fbdc8d1fda5baf78d0231eeff2c904c8f1484
Tested and seems to fix the issue on my dev environment.
