### PR TITLE
Fix for Redis cache check

### DIFF
--- a/server/src/routes/stats.ts
+++ b/server/src/routes/stats.ts
@@ -36,7 +36,7 @@ router.get('/key/:key', async ctx => {
   ctx.set('Content-Type', 'application/json; charset=utf-8')
   const cache = await getCache(`stats:key:${ctx.params.key}`)
 
-  if (cache !== undefined) {
+  if (cache) {
     ctx.set('X-Koa-Redis-Cache', 'true')
     return (ctx.body = cache)
   }
@@ -59,7 +59,7 @@ router.get('/by-hash/:hash', async ctx => {
   ctx.set('Content-Type', 'application/json; charset=utf-8')
   const cache = await getCache(`stats:hash:${ctx.params.hash}`)
 
-  if (cache !== undefined) {
+  if (cache) {
     ctx.set('X-Koa-Redis-Cache', 'true')
     return (ctx.body = cache)
   }


### PR DESCRIPTION
## Proposed Changes
Full disclosure, I could not test the application as I could not get it built. Nevertheless, I looked at the code and I'm convinced that Redis is not returning `undefined`, but rather some other falsy value. I'm not sure what exactly, so I just did a blanket change here. You will definitely want to test this, and it may make sense to also print out exactly what is being returned in the event that a key is not in the cache. That way you don't have a blanket statement here in these if statements. 

(Also, I hope this works).

## Platforms
This pull request modifies: *(select all that apply)*
- [ ] Client
- [X] Server

## Types of Changes
This pull request is contains: *(select all that apply)*
- [X] Bug fixes *(non-breaking change which fixes an issue)*
- [ ] New features *(non-breaking change which adds functionality)*
- [ ] Breaking changes *(fix or feature that would cause existing functionality to not work as expected)*

## Checklist
- [X] I have read the [contribution guidelines](https://github.com/lolPants/beatsaver-reloaded/blob/master/.github/CONTRIBUTING.md)
- [X] I have checked the changes adhere to the project's style guide and all tests pass
- [X] I have (to the best of my ability) checked for vulnerabilities, or any ways that my code could be abused and concluded that it is safe to run in production

## Further Comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
