### PR TITLE
Add links to dev docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ It is recommended to use Redis caching and a long, random JWT token in productio
 Configuration is done using environment variables. Please refer to `.env.example` for more information.
 
 ## 🔧 Developing
-If you wish to contribute, please refer to the [contribution guidelines](https://github.com/lolPants/beatsaver-reloaded/blob/master/.github/CONTRIBUTING.md) or the documentation.
+If you wish to contribute, please refer to the [contribution guidelines](https://github.com/lolPants/beatsaver-reloaded/blob/master/.github/CONTRIBUTING.md) or the [documentation](https://github.com/lolPants/beatsaver-reloaded/blob/master/docs/content/README.md).
 
 ## ℹ Documentation
-Documentation is available as a vuepress site at `/docs`.
+Documentation is available as a vuepress site at `/docs`, or [here on GitHub](https://github.com/lolPants/beatsaver-reloaded/blob/master/docs/content/README.md).
 
 The code that builds the site is licensed under the [project's ISC License](https://github.com/lolPants/beatsaver-reloaded/blob/master/LICENSE). However the content of the documentation is licensed using the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0) license, as documented [here](https://github.com/lolPants/beatsaver-reloaded/tree/master/docs/LICENSE).


### PR DESCRIPTION
## Proposed Changes
Currently the README suggests going to `/docs` in the client after it is running, but that assumes you're able to get the client running without knowledge of how to run it.
`beatsaver.com/docs` also appears to be remapped to `docs.beatsaver.com`, making this even more difficult to find.
However, since you're not running the one running `beatsaver.com`, this simply links to the docs here on the git repo instead.

## Platforms
This pull request modifies: *(select all that apply)*
- [ ] Client
- [ ] Server

## Types of Changes
This pull request is contains: *(select all that apply)*
- [ ] Bug fixes *(non-breaking change which fixes an issue)*
- [ ] New features *(non-breaking change which adds functionality)*
- [ ] Breaking changes *(fix or feature that would cause existing functionality to not work as expected)*

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/lolPants/beatsaver-reloaded/blob/master/.github/CONTRIBUTING.md)
- [x] I have checked the changes adhere to the project's style guide and all tests pass
- [x] I have (to the best of my ability) checked for vulnerabilities, or any ways that my code could be abused and concluded that it is safe to run in production

## Further Comments
Edited to move changes to correct section 