### PR TITLE
Track which user deletes a beatmap

### DIFF
--- a/server/src/mongo/models/Beatmap.ts
+++ b/server/src/mongo/models/Beatmap.ts
@@ -19,6 +19,7 @@ export interface IBeatmapLean {
   uploader: IUserModel['_id']
   uploaded: Date
   deletedAt: Date | null
+  deletedBy: IUserModel['_id'] | null
 
   metadata: {
     songName: string
@@ -82,6 +83,12 @@ const schema: Schema = new Schema({
   },
 
   deletedAt: { type: Date, default: null, index: true, es_indexed: true },
+  deletedBy: {
+    es_indexed: true,
+    es_schema: userSchema,
+    ref: 'user',
+    type: Schema.Types.ObjectId,
+  },
   uploaded: { type: Date, default: Date.now, index: true, es_indexed: true },
   uploader: {
     es_indexed: true,

--- a/server/src/routes/manage.ts
+++ b/server/src/routes/manage.ts
@@ -50,6 +50,7 @@ router.post('/delete/:key', userBeatmap, async ctx => {
   const map: IBeatmapModel = ctx.beatmap
 
   map.deletedAt = new Date()
+  map.deletedBy = ctx.state.user.id
   await map.save()
 
   await Promise.all([


### PR DESCRIPTION
## Proposed Changes
Currently there is no way to tell when a beatmap is removed by an admin, or who removed it.
These changes store which user deletes a beatmap inside of the db entry for that beatmap.
In the future, this could be used to make a simple audit log.

## Platforms
This pull request modifies: *(select all that apply)*
- [ ] Client
- [x] Server

## Types of Changes
This pull request is contains: *(select all that apply)*
- [ ] Bug fixes *(non-breaking change which fixes an issue)*
- [x] New features *(non-breaking change which adds functionality)*
- [ ] Breaking changes *(fix or feature that would cause existing functionality to not work as expected)*

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/lolPants/beatsaver-reloaded/blob/master/.github/CONTRIBUTING.md)
- [x] I have checked the changes adhere to the project's style guide and all tests pass
- [x] I have (to the best of my ability) checked for vulnerabilities, or any ways that my code could be abused and concluded that it is safe to run in production

## Further Comments
Tested and works in my dev environment.
![image](https://user-images.githubusercontent.com/27714637/80858935-db4fe380-8c11-11ea-9f06-17027134a92b.png)