### PR TITLE
Support "2 Click Install" feature

### DIFF
--- a/client/src/ts/components/Beatmap/BeatmapResult.tsx
+++ b/client/src/ts/components/Beatmap/BeatmapResult.tsx
@@ -113,30 +113,32 @@ const BeatmapResult: FunctionComponent<IProps> = ({
           </div>
 
           <div className='is-button-group'>
-            <a
-              href='/'
-              className={clsx(
-                preview.loading && preview.key === map.key && 'loading',
-                preview.loading && 'disabled'
-              )}
-              onClick={e => {
-                e.preventDefault()
+            {!map.metadata.requiresExternalAudioFile && (
+              <a
+                href='/'
+                className={clsx(
+                  preview.loading && preview.key === map.key && 'loading',
+                  preview.loading && 'disabled'
+                )}
+                onClick={e => {
+                  e.preventDefault()
 
-                if (preview.state === 'playing' && preview.key === map.key) {
-                  stopPreview()
-                } else {
-                  previewBeatmap(map)
-                }
-              }}
-            >
-              {preview.key !== map.key
-                ? 'Preview'
-                : preview.loading
-                ? 'Preview'
-                : preview.error !== null
-                ? 'Playback error!'
-                : 'Stop Preview'}
-            </a>
+                  if (preview.state === 'playing' && preview.key === map.key) {
+                    stopPreview()
+                  } else {
+                    previewBeatmap(map)
+                  }
+                }}
+              >
+                {preview.key !== map.key
+                  ? 'Preview'
+                  : preview.loading
+                  ? 'Preview'
+                  : preview.error !== null
+                  ? 'Playback error!'
+                  : 'Stop Preview'}
+              </a>
+            )}
             <a href={`beatsaver://${map.key}`}>OneClick&trade;</a>
             <a
               href='/'

--- a/client/src/ts/components/Beatmap/Detail.tsx
+++ b/client/src/ts/components/Beatmap/Detail.tsx
@@ -357,30 +357,32 @@ const BeatmapDetail: FunctionComponent<IProps> = ({
             Download
           </a>
           <a href={`beatsaver://${map.key}`}>OneClick&trade; Install</a>
-          <a
-            href='/'
-            className={clsx(
-              preview.loading && preview.key === map.key && 'loading',
-              preview.loading && 'disabled'
-            )}
-            onClick={e => {
-              e.preventDefault()
+          {!map.metadata.requiresExternalAudioFile && (
+            <a
+              href='/'
+              className={clsx(
+                preview.loading && preview.key === map.key && 'loading',
+                preview.loading && 'disabled'
+              )}
+              onClick={e => {
+                e.preventDefault()
 
-              if (preview.state === 'playing' && preview.key === map.key) {
-                stopPreview()
-              } else {
-                previewBeatmap(map)
-              }
-            }}
-          >
-            {preview.loading
-              ? '.'
-              : preview.key !== map.key
-              ? 'Preview'
-              : preview.error !== null
-              ? 'Playback error!'
-              : 'Stop Preview'}
-          </a>
+                if (preview.state === 'playing' && preview.key === map.key) {
+                  stopPreview()
+                } else {
+                  previewBeatmap(map)
+                }
+              }}
+            >
+              {preview.loading
+                ? '.'
+                : preview.key !== map.key
+                ? 'Preview'
+                : preview.error !== null
+                ? 'Playback error!'
+                : 'Stop Preview'}
+            </a>
+          )}
           {/* <a href='/'>View on BeastSaber</a> */}
           <a href='/' onClick={e => copyBSR(e)}>
             {copied ? (

--- a/client/src/ts/components/Beatmap/Statistics.tsx
+++ b/client/src/ts/components/Beatmap/Statistics.tsx
@@ -90,6 +90,15 @@ export const BeatmapStats: FunctionComponent<IProps> = ({
           hover='Beatmap Duration'
         />
       ) : null}
+
+      {isFullMap(map) && map.metadata.requiresExternalAudioFile ? (
+        <Statistic
+          type='text'
+          emoji='💿'
+          text='BYOS'
+          hover='Bring your own song file'
+        />
+      ) : null}
     </ul>
   )
 }

--- a/client/src/ts/remote/beatmap.d.ts
+++ b/client/src/ts/remote/beatmap.d.ts
@@ -16,6 +16,7 @@ declare interface IBeatmap {
     songSubName: string
     songAuthorName: string
     levelAuthorName: string
+    requiresExternalAudioFile: boolean
 
     bpm: number
     duration?: number

--- a/client/src/ts/store/audio/actions.ts
+++ b/client/src/ts/store/audio/actions.ts
@@ -10,6 +10,10 @@ export const previewBeatmap: (
 ) => TypedThunk = beatmap => async (dispatch, getState) => {
   stopPreview()(dispatch, getState)
 
+  if (beatmap.metadata.requiresExternalAudioFile) {
+    return
+  }
+
   dispatch({
     payload: true,
     type: AudioActionTypes.SET_LOADING,

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -43,7 +43,8 @@ export const FILE_TYPE_BLACKLIST = [
 ]
 
 const SCHEMA_BASE_URI =
-  'https://raw.githubusercontent.com/lolPants/beatmap-schemas/master/schemas'
+  'https://raw.githubusercontent.com/idolize/beatmap-schemas/master/schemas'
 
 export const SCHEMA_INFO = `${SCHEMA_BASE_URI}/info.schema.json`
 export const SCHEMA_DIFFICULTY = `${SCHEMA_BASE_URI}/difficulty.schema.json`
+export const SCHEMA_AUDIO_CONFIG = `${SCHEMA_BASE_URI}/audio.schema.json`

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -43,7 +43,7 @@ export const FILE_TYPE_BLACKLIST = [
 ]
 
 const SCHEMA_BASE_URI =
-  'https://raw.githubusercontent.com/idolize/beatmap-schemas/master/schemas'
+  'https://raw.githubusercontent.com/lolPants/beatmap-schemas/master/schemas'
 
 export const SCHEMA_INFO = `${SCHEMA_BASE_URI}/info.schema.json`
 export const SCHEMA_DIFFICULTY = `${SCHEMA_BASE_URI}/difficulty.schema.json`

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -14,6 +14,7 @@ export const FILE_EXT_WHITELIST = [
   '.jpg',
   '.jpeg',
   '.srt',
+  '.bin',
 ]
 
 export const FILE_TYPE_BLACKLIST = [

--- a/server/src/mongo/models/Beatmap.ts
+++ b/server/src/mongo/models/Beatmap.ts
@@ -25,6 +25,7 @@ export interface IBeatmapLean {
     songSubName: string
     songAuthorName: string
     levelAuthorName: string
+    requiresExternalAudioFile: boolean
 
     duration: number
     bpm: number
@@ -112,6 +113,7 @@ const schema: Schema = new Schema({
       type: String,
     },
     songSubName: { type: String, maxlength: 255, es_indexed: false },
+    requiresExternalAudioFile: { type: Boolean, default: false },
 
     bpm: { type: Number, required: true },
 

--- a/server/src/routes/upload/errors.ts
+++ b/server/src/routes/upload/errors.ts
@@ -141,3 +141,17 @@ export const ERR_BEATMAP_PARSE_TIMEOUT = new CodedError(
   'ERR_BEATMAP_PARSE_TIMEOUT',
   408
 )
+
+export const ERR_BEATMAP_INVALID_AUDIO_CONFIG = new CodedError(
+  'invalid audio.config file',
+  0x30012,
+  'ERR_BEATMAP_INVALID_AUDIO_CONFIG',
+  400
+)
+
+export const ERR_BEATMAP_MISSING_FINGERPRINT = new CodedError(
+  'beatmap missing fingerprint.bin file',
+  0x30013,
+  'ERR_BEATMAP_MISSING_FINGERPRINT',
+  400
+)

--- a/server/src/routes/upload/types.ts
+++ b/server/src/routes/upload/types.ts
@@ -72,6 +72,7 @@ declare interface IParsedBeatmap {
     songSubName: string
     songAuthorName: string
     levelAuthorName: string
+    requiresExternalAudioFile: boolean
 
     duration: number
     bpm: number
@@ -110,4 +111,22 @@ declare interface IParsedDifficulty {
   obstacles: number
   njs: number
   njsOffset: number
+}
+
+declare interface IAudioConfig {
+  schemaVersion: number
+  lengthMs: number
+  notes?: string
+  downloadUrls?: string[]
+  knownGoodHashes?: Array<{ type: string, hash: string }>
+  patches?: {
+    delayStartMs?: number
+    padEndMs?: number
+    trim?: {
+      startMs?: number
+      endMs: number
+    }
+    fadeIn?: { startMs: number, durationMs: number }
+    fadeOut?: { startMs: number, durationMs: number }
+  }
 }


### PR DESCRIPTION
## Proposed Changes
Support for uploading custom maps without audio files to BeatSaver
- Add `requiresExternalAudioFile ` boolean to the beatmap metadata
- Set `requiresExternalAudioFile` to true if the zip file contains audio.json and fingerprint.bin
- If `requiresExternalAudioFile`, determine song length via audio.json instead of ffprobe
- If `requiresExternalAudioFile`, disable in-browser preview functionality
- If `requiresExternalAudioFile`, show "bring your own song" indicator in stats area

## Platforms
This pull request modifies: *(select all that apply)*
- [x] Client
- [x] Server

## Types of Changes
This pull request is contains: *(select all that apply)*
- [ ] Bug fixes *(non-breaking change which fixes an issue)*
- [x] New features *(non-breaking change which adds functionality)*
- [ ] Breaking changes *(fix or feature that would cause existing functionality to not work as expected)*

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/lolPants/beatsaver-reloaded/blob/master/.github/CONTRIBUTING.md)
- [x] I have checked the changes adhere to the project's style guide and all tests pass
- [x] I have (to the best of my ability) checked for vulnerabilities, or any ways that my code could be abused and concluded that it is safe to run in production

## Further Comments
This is part of a series of changes aimed at allowing custom maps to be created, uploaded, and used all without distributing any song file directly (instead the user must supply their own song). 

https://github.com/lolPants/beatmap-schemas/pull/10
https://github.com/Assistant/ModAssistant/pull/232