### PR TITLE
Add 1 day of cache to CDN route

### DIFF
--- a/server/src/routes/cdn.ts
+++ b/server/src/routes/cdn.ts
@@ -6,5 +6,7 @@ const router = new Router({
   prefix: '/cdn',
 })
 
-serve(CDN_PATH, router)
+serve(CDN_PATH, router, {
+  maxage: 86400000 // Cache downloads for 24 hours
+})
 export { router as cdnRouter }

--- a/server/src/routes/cdn.ts
+++ b/server/src/routes/cdn.ts
@@ -7,6 +7,6 @@ const router = new Router({
 })
 
 serve(CDN_PATH, router, {
-  maxage: 86400000 // Cache downloads for 24 hours
+  maxage: 86400000, // Cache downloads for 24 hours
 })
 export { router as cdnRouter }


### PR DESCRIPTION
## Proposed Changes
I've add a max-age directive to the cdn route, this will cause cloudflare to cache zip downloads for a day, significantly reducing origin load

## Platforms
This pull request modifies: *(select all that apply)*
- [ ] Client
- [x] Server

## Types of Changes
This pull request is contains: *(select all that apply)*
- [x] Bug fixes *(non-breaking change which fixes an issue)*
- [ ] New features *(non-breaking change which adds functionality)*
- [ ] Breaking changes *(fix or feature that would cause existing functionality to not work as expected)*

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/lolPants/beatsaver-reloaded/blob/master/.github/CONTRIBUTING.md)
- [x] I have checked the changes adhere to the project's style guide and all tests pass
- [x] I have (to the best of my ability) checked for vulnerabilities, or any ways that my code could be abused and concluded that it is safe to run in production

## Further Comments
I've set the `maxage` to 24 hours, which is pretty short. This can definitely be increased.
