### PR TITLE
Fix wrong style of result item on device with small width.

### DIFF
--- a/client/src/sass/_beatmap-result.scss
+++ b/client/src/sass/_beatmap-result.scss
@@ -47,6 +47,7 @@ div.beatmap-result {
 
     @media screen and (max-width: $hide-cover) {
       border-radius: $radius;
+      flex-direction: column;
     }
 
     display: flex;
@@ -60,6 +61,24 @@ div.beatmap-result {
 
         text-align: right;
         color: rgb(23, 23, 24);
+
+        & > ul {
+          & .text {
+            margin: .25em;
+          }
+
+          @media screen and (max-width: $hide-cover) {
+            display: flex;
+            flex-wrap: wrap;
+            padding: .5em 0;
+            li {
+              display: flex;
+              flex-direction: row-reverse;
+              align-items: center;
+              margin: .25em;
+            }
+          }
+        }
       }
 
       & .is-button-group {

--- a/client/src/ts/components/Beatmap/Statistic.tsx
+++ b/client/src/ts/components/Beatmap/Statistic.tsx
@@ -33,8 +33,8 @@ export const Statistic: FunctionComponent<IStatProps> = props => {
 
     return (
       <li className='mono' title={hover}>
-        {num}
-        {percentage !== undefined ? '%' : ''} {emoji}
+        <span className='text'>{num}{percentage !== undefined ? '%' : ''}</span>
+        <span className='emoji'>{emoji}</span>
       </li>
     )
   } else if (props.type === 'text') {
@@ -42,7 +42,7 @@ export const Statistic: FunctionComponent<IStatProps> = props => {
 
     return (
       <li className='mono' title={hover}>
-        {text} {emoji}
+        <span className='text'>{text}</span><span className='emoji'>{emoji}</span>
       </li>
     )
   }


### PR DESCRIPTION
## Proposed Changes
Fix wrong style of result item on device with small width.

## Platforms
This pull request modifies: *(select all that apply)*
- [x] Client
- [ ] Server

## Types of Changes
This pull request is contains: *(select all that apply)*
- [x] Bug fixes *(non-breaking change which fixes an issue)*
- [ ] New features *(non-breaking change which adds functionality)*
- [ ] Breaking changes *(fix or feature that would cause existing functionality to not work as expected)*

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/lolPants/beatsaver-reloaded/blob/master/.github/CONTRIBUTING.md)
- [x] I have checked the changes adhere to the project's style guide and all tests pass
- [x] I have (to the best of my ability) checked for vulnerabilities, or any ways that my code could be abused and concluded that it is safe to run in production

## Further Comments
**Before:**
![QQ截图20210509111620](https://user-images.githubusercontent.com/45550579/117559556-ece78900-b0b8-11eb-8803-81823d8bde6c.png)

**After:**
![QQ截图20210509111421](https://user-images.githubusercontent.com/45550579/117559562-f244d380-b0b8-11eb-9b13-c0d2feb1765a.png)

